### PR TITLE
Add title length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # plugin-megazone-sms-notification-protocol
 
 Plugin for SMS Protocol
-- Notification through Megazone Message service (SMS)
+- Notification through Megabird service for SMS. 
+- [Megabird](https://megabird.com/) is an integrated messaging service by Megazone Cloud.
 
 Find us also at [Dockerhub](https://hub.docker.com/repository/docker/spaceone/plugin-sms-voicecall-notification-protocol)
-> Latest stable version : 1.0.1
+> Latest stable version : 1.1.1
 
 Please contact us if you need any further information. (<support@spaceone.dev>)
 
 ---
 
 ## Release Note
+
+### Ver 1.1.1
+* Be implemented to Megabird connectors (#1)
+* Check message title length limit (#5)
 
 ### Ver 1.0.2
 * update message format

--- a/src/spaceone/notification/conf/megabird_conf.py
+++ b/src/spaceone/notification/conf/megabird_conf.py
@@ -3,5 +3,6 @@ ENDPOINT_URL = 'https://api.megabird.co.kr:8080'
 TITLE = '알람 발생'
 TYPE = 'MMS'
 SENDER = '16442243'
+MAX_TITLE_LEN = 30
 
 

--- a/src/spaceone/notification/connector/megabird.py
+++ b/src/spaceone/notification/connector/megabird.py
@@ -27,7 +27,7 @@ class MegabirdConnector(BaseConnector):
 
         body = {
             'svcKndCd': TYPE,
-            'msgTtl': title,
+            'msgTtl': title[:MAX_TITLE_LEN],
             'msgCotn': body,
             'adIncluYn': 'N',
             'snPhnum': SENDER,


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Check that the SMS message title has a length limit.
Since a 400 Bad Request error occurs when the 30 characters more, truncating when the title length exceeds 30 characters.

### ReleKnown issue
* https://github.com/cloudforet-io/plugin-mzc-sms-noti-protocol/issues/5