### PR TITLE
Modify contents type to LMS

### DIFF
--- a/src/spaceone/notification/conf/megabird_conf.py
+++ b/src/spaceone/notification/conf/megabird_conf.py
@@ -1,7 +1,7 @@
 ENDPOINT_URL = 'https://api.megabird.co.kr:8080'
 
 TITLE = '알람 발생'
-TYPE = 'MMS'
+TYPE = 'LMS'
 SENDER = '16442243'
 MAX_TITLE_LEN = 30
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
MMS is a type used when multimedia contents such as images are included and LMS type is used when only text. 
Currently, We are send text only for alarm delivery, so it is recommended to send in LMS type. (LMS is cheaper than MMS)
